### PR TITLE
Add PhpStorm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Installation
-Copy `Dockerfile.xml` to `<IDEA_config_folder>/filetypes` and restart IDEA.
+Copy `Dockerfile.xml` to `<YOURIDE_config_folder>/filetypes` and restart your IDE (IDEA / PhpStorm).
 
 ### IntelliJ IDEA 13
 #### Linux

--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ curl --create-dirs -so ~/Library/Preferences/IdeaIC14/filetypes/Dockerfile.xml h
 ```bash
 curl --create-dirs -so ~/Library/Preferences/IntelliJIdea14/filetypes/Dockerfile.xml https://raw.githubusercontent.com/masgari/docker-intellij-idea/master/Dockerfile.xml
 ```
+### PhpStorm 9
+#### Linux 
+```bash
+wget -O ~/.WebIde90/config/filetypes/Dockerfile.xml https://raw.githubusercontent.com/masgari/docker-intellij-idea/master/Dockerfile.xml
+```


### PR DESCRIPTION
Many thanks for this Dockerfile syntax highlighting.

It works well also in PhpStorm, so I added the installation instructions in the documentation