### PR TITLE
WORKDIR and ARG keywords are not recognized

### DIFF
--- a/Dockerfile.xml
+++ b/Dockerfile.xml
@@ -8,7 +8,7 @@
       <option name="HEX_PREFIX" value="" />
       <option name="NUM_POSTFIXES" value="" />
     </options>
-    <keywords keywords="ADD;ATTACH;CMD;COPY;ENTRYPOINT;ENV;EXPORT;EXPOSE;FROM;IMPORT;INCLUDE;LABEL;MAINTAINER;MOUNT;ONBUILD;PUSH;REQUIRE;RUN;TAG;USER;VAR;VOLUME;WORKDIR,ARG" ignore_case="false" />
+    <keywords keywords="ADD;ATTACH;ARG;CMD;COPY;ENTRYPOINT;ENV;EXPORT;EXPOSE;FROM;IMPORT;INCLUDE;LABEL;MAINTAINER;MOUNT;ONBUILD;PUSH;REQUIRE;RUN;TAG;USER;VAR;VOLUME;WORKDIR" ignore_case="false" />
     <keywords2 keywords="add-apt-repository;apt-key;apt-add-repository;addgroup;yum;adduser;apt-get;cd;mv;chmod;chown;cp;curl;dpkg;dpkg-divert;echo;ln;mkdir;printf;rm;rsync;sed;tar;wget;apk;unzip;nano;bash;sh;ash;pip" />
     <keywords3 keywords="install;update;upgrade;remove;autoremove;purge;source;build-dep;dist-upgrade;dselect-upgrade;clean;autoclean;check;changelog;download;del;add;uninstall;" />
     <keywords4 keywords="-a;-b;-c;-d;-e;-f;-g;-h;-i;-j;-k;-l;-m;-n;-o;-p;-q;-r;-s;-t;-u;-v;-w;-x;-y;-z;+a;+b;+c;+d;+e;+f;+g;+h;+i;+j;+k;+l;+m;+n;+o;+p;+q;+r;+s;+t;+u;+v;+w;+x;+y;+z;+A;+B;+C;+D;+E;+F;+G;+H;+I;+J;+K;+L;+M;+N;+O;+P;+Q;+R;+S;+T;+U;+V;+W;+X;+Y;+Z;-A;-B;-C;-D;-E;-F;-G;-H;-I;-J;-K;-L;-M;-N;-O;-P;-Q;-R;-S;-T;-U;-V;-W;-X;-Y;-Z;--disabled-password;--force-yes;--gecos;--ingroup;--quiet;-fr;-rf;--no-cache;--no-network;--purge;--no-cache-dir;--proxy" />


### PR DESCRIPTION
Hello,

due to a coma instead of a semicolon between `WORKDIR` and `ARG`, both keywords are not recognized.

Thanks for merging PR.

Regards,
Thomas
